### PR TITLE
[change] top-most routerDelegate to RootRouterDelegate

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  final routerDelegate = BeamerRouterDelegate(
+  final routerDelegate = RootRouterDelegate(
     locationBuilder: BeamerLocationBuilder(
       beamLocations: [
         RootLocation(),
@@ -20,7 +20,8 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       routeInformationParser: BeamerRouteInformationParser(),
       routerDelegate: routerDelegate,
-      backButtonDispatcher: BeamerBackButtonDispatcher(delegate: routerDelegate),
+      backButtonDispatcher:
+          BeamerBackButtonDispatcher(delegate: routerDelegate),
     );
   }
 }


### PR DESCRIPTION
Top-most router delegate needs to be `RootRouterDelegate` if we have `Beamer`s bellow, i.e. nested navigation is used.

I'm working to change that for `v1.0.0` so everything will be `BeamerRouterDelegate` without any further action needed by the developer. Delegates will detect themselves if they have a parent or not.